### PR TITLE
Fix links in emails

### DIFF
--- a/aws-env.dev
+++ b/aws-env.dev
@@ -35,7 +35,7 @@
 
 # Variables that are built from other variables:
 
-	export ROOT_URL=https://case.dev.ins.unee-t.com
+	export ROOT_URL=https://case.$STAGE.$DOMAIN
 	export BUGZILLA_URL=https://dashboard.$STAGE.$DOMAIN
 
 	export CLOUDINARY_API_ENDPOINT=https://api.cloudinary.com/v1_1/$CLOUDINARY_CLOUD_NAME/auto/upload

--- a/imports/email-templates/case-assignee-updated.js
+++ b/imports/email-templates/case-assignee-updated.js
@@ -5,17 +5,25 @@ import notificationEmailLayout from './components/notification-email-layout'
 export default (assignee, notificationId, settingType, unitMeta, unitCreator, caseTitle, caseId) => {
   const casePath = getCaseAccessPath(assignee, caseId, unitMeta.bzId)
 
-  const optOutUrl = createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })
+  const optOutUrl = url.resolve(process.env.ROOT_URL, `/notification-settings`)
+// Function `createEngagementLink` is not working - see GH issue #26
+// ---> Commenting out as a quick fix.
+  //   createEngagementLink({
+  //   url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
+  //   id: notificationId,
+  //   email: assignee.emails[0].address
+  // })
+// END quickfix
 
-  const accessUrl = createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })
+  const accessUrl = url.resolve(process.env.ROOT_URL, `casePath`)
+// Function `createEngagementLink` is not working - see GH issue #26
+// ---> Commenting out as a quick fix.
+  //   createEngagementLink({
+  //   url: url.resolve(process.env.ROOT_URL, casePath),
+  //   id: notificationId,
+  //   email: assignee.emails[0].address
+  // })
+// END quickfix
 
   return {
     subject: `Assigned to ${caseTitle} in ${unitMeta.displayName} at ${unitMeta.streetAddress}`,

--- a/imports/email-templates/case-new-message.js
+++ b/imports/email-templates/case-new-message.js
@@ -4,16 +4,27 @@ import notificationEmailLayout from './components/notification-email-layout'
 
 export default (assignee, notificationId, settingType, unitMeta, unitCreator, caseTitle, caseId, user, message) => {
   const casePath = getCaseAccessPath(assignee, caseId, unitMeta.bzId)
-  const accessUrl = createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })
-  const optOutUrl = createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })
+
+  const accessUrl = url.resolve(process.env.ROOT_URL, casePath)
+// Function `createEngagementLink` is not working - see GH issue #26
+// ---> Commenting out as a quick fix.
+  // createEngagementLink({
+  //   url: url.resolve(process.env.ROOT_URL, casePath),
+  //   id: notificationId,
+  //   email: assignee.emails[0].address
+  // })
+// END quickfix
+
+  const optOutUrl = url.resolve(process.env.ROOT_URL, '/notification-settings')
+// Function `createEngagementLink` is not working - see GH issue #26
+// ---> Commenting out as a quick fix.
+  // createEngagementLink({
+  //   url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
+  //   id: notificationId,
+  //   email: assignee.emails[0].address
+  // })
+// END quickfix
+
   return {
     subject: `New message on case ${caseTitle} in ${unitMeta.displayName} at ${unitMeta.streetAddress}`,
     ...notificationEmailLayout({

--- a/imports/email-templates/case-updated.js
+++ b/imports/email-templates/case-updated.js
@@ -5,17 +5,26 @@ import notificationEmailLayout from './components/notification-email-layout'
 export default (assignee, notificationId, settingType, unitMeta, unitCreator, caseTitle, caseId, message, user) => {
   const casePath = getCaseAccessPath(assignee, caseId, unitMeta.bzId)
 
-  const optOutUrl = createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })
+  const optOutUrl = url.resolve(process.env.ROOT_URL, `/notification-settings`)
+// Function `createEngagementLink` is not working - see GH issue #26
+// ---> Commenting out as a quick fix.
+  // createEngagementLink({
+  //   url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
+  //   id: notificationId,
+  //   email: assignee.emails[0].address
+  // })
+// END quickfix
 
-  const accessUrl = createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })
+  const accessUrl = url.resolve(process.env.ROOT_URL, `casePath`)
+// Function `createEngagementLink` is not working - see GH issue #26
+// ---> Commenting out as a quick fix.
+  // createEngagementLink({
+  //   url: url.resolve(process.env.ROOT_URL, casePath),
+  //   id: notificationId,
+  //   email: assignee.emails[0].address
+  // })
+// END quickfix
+
   return {
     subject: `Case updated ${caseTitle} in ${unitMeta.displayName} at ${unitMeta.streetAddress}`,
     ...notificationEmailLayout({

--- a/imports/email-templates/case-user-invited.js
+++ b/imports/email-templates/case-user-invited.js
@@ -5,17 +5,25 @@ import notificationEmailLayout from './components/notification-email-layout'
 export default (invitee, notificationId, settingType, unitMeta, unitCreator, caseTitle, caseId) => {
   const casePath = getCaseAccessPath(invitee, caseId, unitMeta.bzId)
 
-  const optOutUrl = createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
-    id: notificationId,
-    email: invitee.emails[0].address
-  })
+  const optOutUrl = url.resolve(process.env.ROOT_URL, `/notification-settings`)
+// Function `createEngagementLink` is not working - see GH issue #26
+// ---> Commenting out as a quick fix.
+  // createEngagementLink({
+  //   url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
+  //   id: notificationId,
+  //   email: invitee.emails[0].address
+  // })
+// END quickfix
 
-  const accessUrl = createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: invitee.emails[0].address
-  })
+  const accessUrl =  url.resolve(process.env.ROOT_URL, `casePath`)
+// Function `createEngagementLink` is not working - see GH issue #26
+// ---> Commenting out as a quick fix.
+  // createEngagementLink({
+  //   url: url.resolve(process.env.ROOT_URL, casePath),
+  //   id: notificationId,
+  //   email: invitee.emails[0].address
+  // })
+// END quickfix
 
   return {
     subject: `Collaborate on "${caseTitle}"`,

--- a/imports/email-templates/new-case-assigned.js
+++ b/imports/email-templates/new-case-assigned.js
@@ -5,17 +5,24 @@ import notificationEmailLayout from './components/notification-email-layout'
 export default (assignee, notificationId, settingType, unitMeta, unitCreator, caseTitle, caseId) => {
   const casePath = getCaseAccessPath(assignee, caseId, unitMeta.bzId)
 
-  const optOutUrl = createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })
-
-  const accessUrl = createEngagementLink({
-    url: url.resolve(process.env.ROOT_URL, casePath),
-    id: notificationId,
-    email: assignee.emails[0].address
-  })
+  const optOutUrl = url.resolve(process.env.ROOT_URL, `/notification-settings`)
+// Function `createEngagementLink` is not working - see GH issue #26
+// ---> Commenting out as a quick fix.
+  // createEngagementLink({
+  //   url: url.resolve(process.env.ROOT_URL, '/notification-settings'),
+  //   id: notificationId,
+  //   email: assignee.emails[0].address
+  // })
+// END quickfix
+  const accessUrl = url.resolve(process.env.ROOT_URL, `casePath`)
+// Function `createEngagementLink` is not working - see GH issue #26
+// ---> Commenting out as a quick fix.
+  // createEngagementLink({
+  //   url: url.resolve(process.env.ROOT_URL, casePath),
+  //   id: notificationId,
+  //   email: assignee.emails[0].address
+  // })
+// END quickfix
 
   return {
     subject: `New case ${caseTitle} in ${unitMeta.displayName} at ${unitMeta.streetAddress} assigned to you`,

--- a/imports/email-templates/unit-user-invited.js
+++ b/imports/email-templates/unit-user-invited.js
@@ -12,26 +12,26 @@ export default (
   const inviteeName = resolveUserName(invitee)
   const invitorName = resolveUserName(invitor)
   return {
-    subject: `Invitation from ${invitorName} to collaborate on property "${unitTitle}"`,
+    subject: `Invitation from ${invitorName} to collaborate on the policy "${unitTitle}"`,
     html: `<img src="cid:logo@unee-t.com" style="width: 100px"/>
 <p>Hi ${inviteeName},</p>
 <p>
-  You've been invited by <strong>${invitorName}</strong> (the <strong>${invitorRoleType}</strong>) to Insure Chat to collaborate on the property: <br />
+  You've been invited by <strong>${invitorName}</strong> (the <strong>${invitorRoleType}</strong>) to Insure Chat to collaborate on the policy: <br />
   <strong>${unitTitle}:</strong><br/>
   ${unitDescription}
 </p>
 <p>
   Your assigned role is <strong>${inviteeRoleType}</strong><br />
-  This invitation allows you to create cases for any issue in this property.<br />
+  This invitation allows you to create cases for any issue in this policy.<br />
   You can also create inspection reports.
 </p>
-<br />Please click on <a href='${accessLink}'>this link</a> to access the property in Insure Chat.
+<br />Please click on <a href='${accessLink}'>this link</a> to access the policy in Insure Chat.
 <br /><br /><small>If the above link does not work, copy & paste this in your browser: ${accessLink}</small>
 
 `,
     text: `Hi ${inviteeName},
 
-You've been invited by ${invitorName} (the ${invitorRoleType}) to Insure Chat to collaborate on the property:
+You've been invited by ${invitorName} (the ${invitorRoleType}) to Insure Chat to collaborate on the policy:
 
 ${unitTitle}:
 
@@ -39,7 +39,7 @@ ${unitDescription}
 
 Your assigned role is "${inviteeRoleType}"
 
-This invitation allow you to create cases for any issue in this property.
+This invitation allow you to create cases for any issue in this policy.
 
 You can also create inspection reports.
 


### PR DESCRIPTION
- Remove previous hotfix (see https://github.com/Unee-T-INS/frontend/commit/c2a4d0324796a62de7554ee6e389d338d241637d)
- Do NOT use the function `createEngagementLink` for now so we can have "clean" links.
- Replace `property` with `policy` in one of the emails.